### PR TITLE
Issue95-Issue91-Unit test: Column string (case: Contains) 

### DIFF
--- a/src/Grid/LocalDataSource.ts
+++ b/src/Grid/LocalDataSource.ts
@@ -153,10 +153,12 @@ export default class LocalDataSource implements IDataSource {
           subset = subset.filter((row) => row[filterableColumn.Name] !== filterableColumn.Filter.Text);
           break;
         case CompareOperators.CONTAINS.toLowerCase():
-          subset = subset.filter((row) => row[filterableColumn.Name].indexOf(filterableColumn.Filter.Text) >= 0);
+          subset = subset.filter((row) => row[filterableColumn.Name].toLowerCase()
+            .indexOf(filterableColumn.Filter.Text.toLowerCase()) >= 0);
           break;
         case CompareOperators.NOT_CONTAINS.toLowerCase():
-          subset = subset.filter((row) => row[filterableColumn.Name].indexOf(filterableColumn.Filter.Text) < 0);
+          subset = subset.filter((row) => row[filterableColumn.Name].toLowerCase()
+            .indexOf(filterableColumn.Filter.Text.toLowerCase()) < 0);
           break;
         case CompareOperators.STARTS_WITH.toLowerCase():
           subset = subset.filter((row) =>

--- a/test/LocalDataSource.spec.tsx
+++ b/test/LocalDataSource.spec.tsx
@@ -13,6 +13,7 @@ import localData from './utils/localData';
 import {
   expectedLocaDataSourcelResponse,
   expectedPayloadBetweenNumeric,
+  expectedPayloadContainsString,
   expectedPayloadDescSortByOrderID,
   expectedPayloadEqualsNumeric,
   expectedPayloadEqualsString,
@@ -240,6 +241,18 @@ describe('LocalDataSource', () => {
 
       dataSource.getAllRecords(10, 0, '').then((response: GridResponse) => {
         expect(response.Payload).to.deep.equal(expectedPayloadEqualsString);
+        done();
+      });
+    });
+
+    it('should return a payload with records where CustomerName contains \'ves\'', (done) => {
+      dataSource.columns[1].Filter.Text = 'ves';
+      dataSource.columns[1].Filter.Operator = 'Contains';
+      dataSource.columns[1].Filter.HasFilter = true;
+      dataSource.columns[1].Filter.Argument = [];
+
+      dataSource.getAllRecords(10, 0, '').then((response: GridResponse) => {
+        expect(response.Payload).to.deep.equal(expectedPayloadContainsString);
         done();
       });
     });

--- a/test/utils/LocalDataSourceMocks.ts
+++ b/test/utils/LocalDataSourceMocks.ts
@@ -745,6 +745,37 @@ const expectedPayloadEqualsString = [
   }
 ];
 
+const expectedPayloadContainsString = [
+  {
+    OrderID: 4,
+    CustomerName: 'Vesta',
+    ShippedDate: '2016-03-19T19:00:00',
+    ShipperCity: 'Portland, OR, USA',
+    Amount: 300
+  },
+  {
+    OrderID: 10,
+    CustomerName: 'Vesta',
+    ShippedDate: '2016-03-19T19:00:00',
+    ShipperCity: 'Portland, OR, USA',
+    Amount: 300
+  },
+  {
+    OrderID: 14,
+    CustomerName: 'Vesta',
+    ShippedDate: '2016-04-23T10:00:00',
+    ShipperCity: 'Guadalajara, JAL, Mexico',
+    Amount: 60
+  },
+  {
+    OrderID: 19,
+    CustomerName: 'Vesta',
+    ShippedDate: '2016-11-08T18:00:00',
+    ShipperCity: 'Guadalajara, JAL, Mexico',
+    Amount: 300
+  }
+];
+
 export {
   expectedPayloadTextSearchVesta,
   expectedPayloadMultipleSort,
@@ -757,6 +788,7 @@ export {
   expectedPayloadLteNumeric,
   expectedPayloadLtNumeric,
   expectedPayloadPage2,
+  expectedPayloadContainsString,
   expectedPayloadNoneString,
   expectedPayloadEqualsString,
   expectedLocaDataSourcelResponse


### PR DESCRIPTION
Unit test added for column filtering (string). Case: Contains.

A little change was made in `LocalDataSource` for this case.