### PR TITLE
Issue113-Unit test: Column date (case: None)

### DIFF
--- a/test/LocalDataSource.spec.tsx
+++ b/test/LocalDataSource.spec.tsx
@@ -23,6 +23,7 @@ import {
   expectedPayloadLteNumeric,
   expectedPayloadLtNumeric,
   expectedPayloadMultipleSort,
+  expectedPayloadNoneDate,
   expectedPayloadNoneNumeric,
   expectedPayloadNoneString,
   expectedPayloadNotEndsWithString,
@@ -226,6 +227,11 @@ describe('LocalDataSource', () => {
       dataSource.columns[0].Filter.Operator = CompareOperators.NONE;
       dataSource.columns[0].Filter.HasFilter = false;
       dataSource.columns[0].Filter.Argument = [];
+
+      dataSource.columns[1].Filter.Text = null;
+      dataSource.columns[1].Filter.Operator = CompareOperators.NONE;
+      dataSource.columns[1].Filter.HasFilter = false;
+      dataSource.columns[1].Filter.Argument = [];
     });
 
     it('should return a payload without filters', (done) => {
@@ -320,6 +326,39 @@ describe('LocalDataSource', () => {
 
       dataSource.getAllRecords(10, 0, '').then((response: GridResponse) => {
         expect(response.Payload).to.deep.equal(expectedPayloadNotEndsWithString);
+        done();
+      });
+    });
+  });
+
+  describe('When date column has filters', () => {
+    const dataSource = new LocalDataSource(localData, validColumnsSample);
+
+    beforeEach(() => {
+      dataSource.columns[0].Filter.Text = null;
+      dataSource.columns[0].Filter.Operator = CompareOperators.NONE;
+      dataSource.columns[0].Filter.HasFilter = false;
+      dataSource.columns[0].Filter.Argument = [];
+
+      dataSource.columns[1].Filter.Text = null;
+      dataSource.columns[1].Filter.Operator = CompareOperators.NONE;
+      dataSource.columns[1].Filter.HasFilter = false;
+      dataSource.columns[1].Filter.Argument = [];
+
+      dataSource.columns[2].Filter.Text = null;
+      dataSource.columns[2].Filter.Operator = CompareOperators.NONE;
+      dataSource.columns[2].Filter.HasFilter = false;
+      dataSource.columns[2].Filter.Argument = [];
+    });
+
+    it('should return a payload without filters', (done) => {
+      dataSource.columns[2].Filter.Text = null;
+      dataSource.columns[2].Filter.Operator = CompareOperators.NONE;
+      dataSource.columns[2].Filter.HasFilter = false;
+      dataSource.columns[2].Filter.Argument = [];
+
+      dataSource.getAllRecords(10, 0, '').then((response: GridResponse) => {
+        expect(response.Payload).to.deep.equal(expectedPayloadNoneDate);
         done();
       });
     });

--- a/test/utils/LocalDataSourceMocks.ts
+++ b/test/utils/LocalDataSourceMocks.ts
@@ -1092,6 +1092,81 @@ const expectedPayloadNotEndsWithString = [
   }
 ];
 
+// Mocks for unit tests for date columns
+
+const expectedPayloadNoneDate = [
+  {
+    OrderID: 1,
+    CustomerName: 'Microsoft',
+    ShippedDate: '2016-03-19T19:00:00',
+    ShipperCity: 'Guadalajara, JAL, Mexico',
+    Amount: 300
+  },
+  {
+    OrderID: 2,
+    CustomerName: 'Microsoft',
+    ShippedDate: '2016-11-08T18:00:00',
+    ShipperCity: 'Los Angeles, CA, USA',
+    Amount: 9
+  },
+  {
+    OrderID: 3,
+    CustomerName: 'Unosquare LLC',
+    ShippedDate: '2016-11-08T18:00:00',
+    ShipperCity: 'Guadalajara, JAL, Mexico',
+    Amount: 92
+  },
+  {
+    OrderID: 4,
+    CustomerName: 'Vesta',
+    ShippedDate: '2016-03-19T19:00:00',
+    ShipperCity: 'Portland, OR, USA',
+    Amount: 300
+  },
+  {
+    OrderID: 5,
+    CustomerName: 'Super La Playa',
+    ShippedDate: '2016-04-23T10:00:00',
+    ShipperCity: 'Leon, GTO, Mexico',
+    Amount: 174
+  },
+  {
+    OrderID: 6,
+    CustomerName: 'OXXO',
+    ShippedDate: '2016-12-22T08:00:00',
+    ShipperCity: 'Guadalajara, JAL, Mexico',
+    Amount: 92
+  },
+  {
+    OrderID: 7,
+    CustomerName: 'Super La Playa',
+    ShippedDate: '2016-03-19T19:00:00',
+    ShipperCity: 'Portland, OR, USA',
+    Amount: 300
+  },
+  {
+    OrderID: 8,
+    CustomerName: 'Super La Playa',
+    ShippedDate: '2016-04-23T10:00:00',
+    ShipperCity: 'Leon, GTO, Mexico',
+    Amount: 15
+  },
+  {
+    OrderID: 9,
+    CustomerName: 'OXXO',
+    ShippedDate: '2016-12-22T08:00:00',
+    ShipperCity: 'Guadalajara, JAL, Mexico',
+    Amount: 92
+  },
+  {
+    OrderID: 10,
+    CustomerName: 'Vesta',
+    ShippedDate: '2016-03-19T19:00:00',
+    ShipperCity: 'Portland, OR, USA',
+    Amount: 300
+  }
+];
+
 export {
   expectedPayloadTextSearchVesta,
   expectedPayloadMultipleSort,
@@ -1112,5 +1187,6 @@ export {
   expectedPayloadStartsWithString,
   expectedPayloadNotStartsWithString,
   expectedPayloadEndsWithString,
-  expectedPayloadNotEndsWithString
+  expectedPayloadNotEndsWithString,
+  expectedPayloadNoneDate
 };


### PR DESCRIPTION
Unit test added for column filtering (date). Case: `None`.

Also, some missing statements were added to `beforeEach()` in the suite of tests for string filtering