### PR TITLE
removed deprecated typography variants

### DIFF
--- a/sample/src/RemoteGridList.tsx
+++ b/sample/src/RemoteGridList.tsx
@@ -72,7 +72,7 @@ class RemoteGridList extends React.Component<IDataGridProps, IDataGridState> {
                             <CardContent>
                               <Typography
                                 gutterBottom={true}
-                                variant='headline'
+                                variant='h5'
                                 component='h2'
                               >
                                 {dato.OrderID} - {dato.CustomerName}

--- a/srcdocs/components/DocumentationList.tsx
+++ b/srcdocs/components/DocumentationList.tsx
@@ -20,7 +20,7 @@ const styles = {
 const DocumentationList = ({ classes }: any) => (
     <Paper className={classes.paper}>
         <List>
-            <Typography variant='headline'>
+            <Typography variant='h5'>
                 Documentation
                         </Typography>
             <Divider />

--- a/srcdocs/components/SampleGridList.tsx
+++ b/srcdocs/components/SampleGridList.tsx
@@ -68,7 +68,7 @@ class SampleGridList extends React.Component<any, any> {
                             <CardContent>
                               <Typography
                                 gutterBottom={true}
-                                variant='headline'
+                                variant='h5'
                                 component='h2'
                               >
                                 {item.OrderID} - {item.CustomerName}

--- a/srcdocs/pages/Documentation/ColumnModel.tsx
+++ b/srcdocs/pages/Documentation/ColumnModel.tsx
@@ -28,7 +28,7 @@ const ColumnModel = (props: any) => {
                 </Hidden>
                 <Grid item={true} xs={12} md={9}>
                     <Paper className={classes.paper} style={{ overflowX: 'auto'}}>
-                        <Typography variant='display1' paragraph={true}> Column Model </Typography>
+                        <Typography variant='h4' paragraph={true}> Column Model </Typography>
                         <Divider />
                         <ColumnModelList />
                     </Paper>

--- a/srcdocs/pages/Documentation/DataSource.tsx
+++ b/srcdocs/pages/Documentation/DataSource.tsx
@@ -49,12 +49,12 @@ const DataSource = ({ classes }: any) => (
     </Hidden>
     <Grid item={true} xs={12} md={9}>
       <Paper className={classes.paper}>
-        <Typography variant='display1' paragraph={true}>
+        <Typography variant='h4' paragraph={true}>
           Data Source
         </Typography>
         <Divider />
         <br />
-        <Typography variant='subheading'>
+        <Typography variant='subtitle1'>
           <code className={classes.code}>{'<DataGrid />'}</code> requires a
           wrapper component to retrieve data. Depends on if we use a local
           data source or a remote data source, these wrappers are:
@@ -65,7 +65,7 @@ const DataSource = ({ classes }: any) => (
               <code className={classes.code}>DataGrid</code> component.
               <br />
           <br />
-          <Typography variant='headline' gutterBottom={true}>
+          <Typography variant='h5' gutterBottom={true}>
             <code className={classes.code}>withRemoteDataSource</code>
           </Typography>
           <code className={classes.code}>withRemoteDataSource</code>
@@ -78,7 +78,7 @@ const DataSource = ({ classes }: any) => (
             {remoteDataSource}
           </Highlight>
           <br />
-          <Typography variant='headline' gutterBottom={true}>
+          <Typography variant='h5' gutterBottom={true}>
             <code className={classes.code}>LocalDataSource</code>
           </Typography>
           <code className={classes.code}>withLocalDataSource</code>

--- a/srcdocs/pages/Documentation/Getting-Started.tsx
+++ b/srcdocs/pages/Documentation/Getting-Started.tsx
@@ -34,15 +34,15 @@ const GettingStarted = ({ classes }: any) => (
     </Hidden>
     <Grid item={true} xs={12} md={9}>
       <Paper className={classes.paper}>
-        <Typography variant='display1' paragraph={true}>
+        <Typography variant='h4' paragraph={true}>
           Getting Started
             </Typography>
         <Divider />
         <br />
-        <Typography variant='headline' paragraph={true}>
+        <Typography variant='h5' paragraph={true}>
           Installation
             </Typography>
-        <Typography variant='subheading' paragraph={true}>
+        <Typography variant='subtitle1' paragraph={true}>
           Tubular-React is available as an
           <a
             href='https://www.npmjs.com/package/tubular-react'
@@ -51,7 +51,7 @@ const GettingStarted = ({ classes }: any) => (
             npm package
           </a>
         </Typography>
-        <Typography variant='headline' paragraph={true}>
+        <Typography variant='h5' paragraph={true}>
           Dependencies
             </Typography>
         <Typography variant='body1' paragraph={true}>
@@ -74,7 +74,7 @@ const GettingStarted = ({ classes }: any) => (
             </li>
           </ul>
         </Typography>
-        <Typography variant='headline' paragraph={true}>
+        <Typography variant='h5' paragraph={true}>
           npm
             </Typography>
         <Typography variant='body1' paragraph={true}>
@@ -86,10 +86,10 @@ const GettingStarted = ({ classes }: any) => (
           {'npm install tubular-react --save'}
         </Highlight>
         <br />
-        <Typography variant='headline' paragraph={true}>
+        <Typography variant='h5' paragraph={true}>
           Usage
             </Typography>
-        <Typography variant='subheading' paragraph={true}>
+        <Typography variant='subtitle1' paragraph={true}>
           Tubular React is an extension of Material-UI which offers until
           now a couple of useful components:
               <br />
@@ -100,7 +100,7 @@ const GettingStarted = ({ classes }: any) => (
           your data, you can populate them from a server-side data source or
           a local data source as an array.
             </Typography>
-        <Typography variant='headline' paragraph={true}>
+        <Typography variant='h5' paragraph={true}>
           
           Quick Start
         </Typography>
@@ -111,10 +111,10 @@ const GettingStarted = ({ classes }: any) => (
         <Highlight language='javascript' className={classes.code}>
           {basicFeatures}
         </Highlight>
-        <Typography variant='headline' paragraph={true}>
+        <Typography variant='h5' paragraph={true}>
           Extend Grid Functionalities
             </Typography>
-        <Typography variant='subheading' paragraph={true}>
+        <Typography variant='subtitle1' paragraph={true}>
           You can add functionalities to the `DataGrid`, including extra
           buttons that can perform an action according to your requirements.
           Just need include an IconButton Component from @material-ui and

--- a/srcdocs/pages/Documentation/Home.tsx
+++ b/srcdocs/pages/Documentation/Home.tsx
@@ -39,11 +39,11 @@ const styles = {
 const Home = ({ classes }: any) => (
       <Grid container={true} spacing={24} className={classes.container}>
         <Paper className={classes.paper}>
-          <Typography variant='display1'>What is it?</Typography>
+          <Typography variant='h4'>What is it?</Typography>
           <Divider />
           <Typography
             paragraph={true}
-            variant='subheading'
+            variant='subtitle1'
             className={classes.content}
           >
             Tubular React is a set of ReactJS components designed to rapidly
@@ -56,14 +56,14 @@ const Home = ({ classes }: any) => (
             searching, besides it has almost the same grid functionalities.
           </Typography>
           <br />
-          <Typography variant='display1'>Features</Typography>
+          <Typography variant='h4'>Features</Typography>
           <Divider />
           <Typography
             paragraph={true}
-            variant='subheading'
+            variant='subtitle1'
             className={classes.content}
           >
-            <Typography variant='headline'>
+            <Typography variant='h5'>
               The main component is a <em>grid</em> with multiple options:
             </Typography>
             <ul>
@@ -86,7 +86,7 @@ const Home = ({ classes }: any) => (
             table and more.
             <br />
             <br />
-            <Typography variant='headline'>
+            <Typography variant='h5'>
               <em>Grid list</em> component allows you to perform some of the
               same options as:
             </Typography>
@@ -104,9 +104,9 @@ const Home = ({ classes }: any) => (
             which helps you to quickly find information.
           </Typography>
           <br />
-          <Typography variant='display1'>Dependencies</Typography>
+          <Typography variant='h4'>Dependencies</Typography>
           <Divider />
-          <Typography paragraph={true} variant='subheading'>
+          <Typography paragraph={true} variant='subtitle1'>
             <ul>
               <li>
                 <a href='https://date-fns.org/'>date-fns - Version: 1.29.0</a>
@@ -127,11 +127,11 @@ const Home = ({ classes }: any) => (
             </ul>
           </Typography>
           <br />
-          <Typography variant='display1'>npm Installation</Typography>
+          <Typography variant='h4'>npm Installation</Typography>
           <Divider />
           <Typography
             paragraph={true}
-            variant='subheading'
+            variant='subtitle1'
             className={classes.content}
           >
             <Highlight language='javascript' className={classes.code}>
@@ -139,11 +139,11 @@ const Home = ({ classes }: any) => (
             </Highlight>
           </Typography>
           <br />
-          <Typography variant='display1'>Usage</Typography>
+          <Typography variant='h4'>Usage</Typography>
           <Divider />
           <Typography
             paragraph={true}
-            variant='subheading'
+            variant='subtitle1'
             className={classes.content}
           >
             Here is a quick example to get you started, <b>it's all you need</b>

--- a/srcdocs/pages/Documentation/Props.tsx
+++ b/srcdocs/pages/Documentation/Props.tsx
@@ -30,10 +30,10 @@ const Props = ({ classes }: any) => (
         </Hidden>
         <Grid item={true} xs={12} md={9}>
             <Paper className={classes.paper}>
-                <Typography variant='display1' paragraph={true}>DataGrid props</Typography>
+                <Typography variant='h4' paragraph={true}>DataGrid props</Typography>
                 <Divider />
                 <br />
-                <Typography variant='subheading'>
+                <Typography variant='subtitle1'>
                     It's important to use <code className={classes.code}>withRemoteDataSource</code> or
                             <code className={classes.code}>withLocalDataSource</code> according to the case
                             to fill the <code className={classes.code}>{'<DataGrid />'}</code> component
@@ -44,7 +44,7 @@ const Props = ({ classes }: any) => (
                         </Typography>
                 <DataGridProps />
                 <br />
-                <Typography variant='subheading'>
+                <Typography variant='subtitle1'>
                     <i>If you don't define some of the optional props described above,
                             these will not be shown. In the case of </i>
                     <code className={classes.code}>bodyRenderer</code>,
@@ -55,17 +55,17 @@ const Props = ({ classes }: any) => (
             </Paper>
             <br />
             <Paper className={classes.paper}>
-                <Typography variant='display1' paragraph={true}>Toolbar options</Typography>
+                <Typography variant='h4' paragraph={true}>Toolbar options</Typography>
                 <Divider />
                 <br />
-                <Typography variant='subheading'>
+                <Typography variant='subtitle1'>
                     If you need personalite the grid adding, removing
                             or modifying  fetures, <code className={classes.code}>ToolBarOptions Class</code>
                     provides several options.
                         </Typography>
                 <ToolBarOptionsProps />
                 <br />
-                <Typography variant='subheading'>
+                <Typography variant='subtitle1'>
                     <i>If you don't define some of the optional props described above,
                             these will set with the default values.</i>
                 </Typography>


### PR DESCRIPTION
it appears some of the used typography variants are deprecated, this throws a warning, 

**what is done in this commit**: 
* replaced the variants for the new ones, according to the following table 
![image](https://user-images.githubusercontent.com/27336508/51714269-54698f80-1ffa-11e9-9b89-189b6f2eab43.png)
