### PR TITLE
Removal of anchor filter from grid state. Fixing multiple bugs

### DIFF
--- a/src/DataGrid/GridHeader.tsx
+++ b/src/DataGrid/GridHeader.tsx
@@ -7,6 +7,7 @@ import FilterList from '@material-ui/icons/FilterList';
 import * as React from 'react';
 import { ColumnModel, ColumnSortDirection, CompareOperators } from 'tubular-common';
 import { IDataGrid } from '../DataGridInterfaces/IDataGrid';
+import { IFilterWrapper } from '../DataGridInterfaces/IFilterWrapper';
 import { DialogModal } from '../Filtering/DialogModal';
 
 interface IGridHeaderCellProps {
@@ -74,14 +75,26 @@ interface IProps {
 }
 
 export const GridHeader: React.FunctionComponent<IProps> = ({ grid }: any) => {
+  const [anchorFilter, setAnchorFilter] = React.useState(null);
+
+  const setActiveColumn = (column: ColumnModel, event: React.MouseEvent<HTMLElement>) => {
+    grid.api.setActiveColumn(column);
+    setAnchorFilter(event.currentTarget);
+  };
+
+  const setFilter = (filter: IFilterWrapper) => {
+    grid.api.setFilter(filter);
+    setAnchorFilter(null);
+  };
+
   return (
     <TableRow>
       {grid.state.activeColumn &&
         <DialogModal
           activeColumn={grid.state.activeColumn}
-          anchorFilter={grid.state.anchorFilter}
-          setAnchorFilter={grid.api.setAnchorFilter}
-          setFilter={grid.api.setFilter}
+          anchorFilter={anchorFilter}
+          setAnchorFilter={setAnchorFilter}
+          setFilter={setFilter}
           handleFilterChange={grid.api.handleFilterChange}
         />}
       {grid.state.columns
@@ -91,7 +104,7 @@ export const GridHeader: React.FunctionComponent<IProps> = ({ grid }: any) => {
             key={column.Name}
             column={column}
             sortColumn={grid.api.sortColumn}
-            setActiveColumn={grid.api.setActiveColumn}
+            setActiveColumn={setActiveColumn}
           />,
         )}
     </TableRow>

--- a/src/DataGridInterfaces/IDataGridApi.ts
+++ b/src/DataGridInterfaces/IDataGridApi.ts
@@ -4,7 +4,6 @@ export interface IDataGridApi {
     handleFilterChange: (value: any) => void;
     processRequest: () => void;
     setActiveColumn: (column: any, event: React.MouseEvent<HTMLElement>) => void;
-    setAnchorFilter: (anchorEl) => void;
     setFilter: (value: any) => void;
     sortColumn: (property: string) => void;
     updateItemPerPage: (itemsPerPage: number) => void;

--- a/src/DataGridInterfaces/IDataGridState.ts
+++ b/src/DataGridInterfaces/IDataGridState.ts
@@ -4,7 +4,6 @@ import { IDataGridStorage } from './IDataGridStorage';
 export interface IDataGridState {
     activeColumn: any;
     aggregate: any;
-    anchorFilter: any;
     columns: ColumnModel[];
     data: any[];
     error: any;

--- a/src/Filtering/DialogModal.tsx
+++ b/src/Filtering/DialogModal.tsx
@@ -26,7 +26,7 @@ const createFilterPatch = (activeColumn: ColumnModel): IFilterWrapper => {
     return {
         Argument: [filterArgument],
         HasFilter: true,
-        Operator: CompareOperators.AUTO,
+        Operator: activeColumn.Filter.Operator || CompareOperators.AUTO,
         Text: filterText,
     };
 };

--- a/src/Hooks/useDataGrid.ts
+++ b/src/Hooks/useDataGrid.ts
@@ -44,7 +44,6 @@ const useDataGrid =
         : IDataGrid => {
 
         const [isLoading, setIsLoading] = React.useState(false);
-        const [getAnchorFilter, setAnchorFilter] = React.useState(null);
         const [getColumns, setColumns] = React.useState(initColumns);
         const [initialized, setInitialized] = React.useState(false);
         const [getActiveColumn, setActiveColumn] = React.useState(null);
@@ -131,13 +130,7 @@ const useDataGrid =
                     setError(err);
                 }
             },
-            setActiveColumn: (column: ColumnModel, event: React.MouseEvent<HTMLElement>) => {
-                setActiveColumn(column);
-                setAnchorFilter(event ? event.currentTarget : null);
-            },
-            setAnchorFilter: (anchorEl: HTMLElement) => {
-                setAnchorFilter(anchorEl);
-            },
+            setActiveColumn,
             setFilter: (value: any) => {
 
                 const columns = [...getColumns];
@@ -153,7 +146,6 @@ const useDataGrid =
                     ...value,
                 };
 
-                setAnchorFilter(null);
                 setColumns([...columns]);
             },
             sortColumn: (property: string) => {
@@ -224,7 +216,6 @@ const useDataGrid =
         const state = {
             ...getState,
             activeColumn: getActiveColumn,
-            anchorFilter: getAnchorFilter,
             columns: getColumns,
             error: getError,
             initialized,

--- a/src/Pagination/Paginator.tsx
+++ b/src/Pagination/Paginator.tsx
@@ -40,7 +40,6 @@ export const Paginator: React.FunctionComponent<any> = ({ grid, rowsPerPageOptio
 
   const newProps = {
     count: state.filteredRecordCount,
-    isLoading: state.isLoading,
     labelDisplayedRows: message(
       state.totalRecordCount,
       state.filteredRecordCount,

--- a/test/useDataGrid.spec.tsx
+++ b/test/useDataGrid.spec.tsx
@@ -32,10 +32,6 @@ describe('useDataGrid', () => {
             expect(grid.state.aggregate).toMatchObject({ CustomerName: 22 });
         });
 
-        test('should have proper anchorFilter', () => {
-            expect(grid.state.anchorFilter).toBeNull();
-        });
-
         test('should have proper column properties', () => {
             expect(grid.state.activeColumn).toBeNull();
             expect(grid.state.columns).toBeDefined();


### PR DESCRIPTION
Anchor filter (element required by Popover on column filtering) used to be stored on the grid state. We decided it should exist outside of the grid state and live directly on the related component.

- I moved that one into GridHeader component and made proper arrangements to make it work.
- I also fixed an issue on filtering due to hardcoded AUTO operator when filtering.
- There was also an issue with paginator, injecting "isLoading" attribute into DOM (check Paginator.tsx change).