### PR TITLE
Proposal for refreshing grid

### DIFF
--- a/sample/src/localDataGrid.tsx
+++ b/sample/src/localDataGrid.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import Button from '@material-ui/core/Button';
 import Snackbar from '@material-ui/core/Snackbar';
 import { DataGrid, LocalStorage } from '../../src';
+import useGridRefresh from '../../src/Hooks/useGridRefresh';
 import { ToolbarOptions } from '../../src/Toolbar/ToolbarOptions';
 import columns from './data/columns';
 import localData from './data/localData';
@@ -12,9 +13,25 @@ const LocalDataGrid: React.FunctionComponent = () => {
   const toolbarOptions = new ToolbarOptions({
     customItems: <Button>Whatever</Button>,
   });
+  const [data, setData] = React.useState(localData);
+  const [refresh, forceRefresh] = useGridRefresh();
 
   const rowClick = (row) => {
     console.log("You clicked on a row: ", row);
+  };
+
+  const forceGridRefresh = () => {
+    forceRefresh();
+  };
+
+  const handleAddRow = () => {
+    setData([...data, {
+      OrderID: 23,
+      CustomerName: 'Tiempo Development',
+      ShippedDate: '2016-01-04T18:00:00',
+      ShipperCity: 'Monterrey, NL, Mexico',
+      Amount: 150.00,
+    }]);
   };
 
   return (
@@ -28,9 +45,12 @@ const LocalDataGrid: React.FunctionComponent = () => {
           message={<span id='message-id'>{getErrorMessage}</span>}
         />
       )}
+      <button onClick={handleAddRow}>Add new row</button>
+      <button onClick={forceGridRefresh}>Force refresh</button>
       <DataGrid
         columns={columns}
-        dataSource={localData}
+        dataSource={data}
+        deps={[refresh]}
         gridName='LocalDataGrid'
         storage={new LocalStorage()}
         onError={setErrorMessage}

--- a/sample/src/remoteDataGrid.tsx
+++ b/sample/src/remoteDataGrid.tsx
@@ -6,6 +6,7 @@ import CheckBox from '@material-ui/icons/CheckBox';
 import CheckBoxOutlineBlank from '@material-ui/icons/CheckBoxOutlineBlank';
 
 import { DataGrid, LocalStorage } from '../../src';
+import useGridRefresh from '../../src/Hooks/useGridRefresh';
 import columns from './data/columns';
 
 // tslint:disable-next-line: no-var-requires
@@ -13,6 +14,12 @@ const format = require('date-fns/format');
 
 const RemoteDataGrid: React.FunctionComponent = () => {
   const [getErrorMessage, setErrorMessage] = React.useState(null as string);
+
+  const [refresh, forceRefresh] = useGridRefresh();
+  const forceGridRefresh = () => {
+    forceRefresh();
+  };
+
   const bodyRenderer = (row: any) => (
     <TableRow hover={true} key={row.OrderID}>
       <TableCell padding='default'>{row.OrderID}</TableCell>
@@ -42,10 +49,12 @@ const RemoteDataGrid: React.FunctionComponent = () => {
 
   return (
     <div className='root'>
+      <button onClick={forceGridRefresh}>Force refresh</button>
       <DataGrid
         gridName='Tubular-React'
         columns={[...columns]}
         dataSource='https://tubular.azurewebsites.net/api/orders/paged'
+        deps={[refresh]}
         bodyRenderer={bodyRenderer}
         footerRenderer={footerRenderer}
         storage={new LocalStorage()}

--- a/src/DataGrid/DataGrid.tsx
+++ b/src/DataGrid/DataGrid.tsx
@@ -33,6 +33,7 @@ const timeout = 400;
 interface IProps {
   columns: ColumnModel[];
   dataSource: any[] | string | Request | ITubularHttpClient;
+  deps?: any[];
   gridName: string;
   storage?: IDataGridStorage;
   toolbarOptions?: ToolbarOptions;
@@ -46,6 +47,7 @@ export const DataGrid: React.FunctionComponent<IProps> = (props) => {
   const {
     bodyRenderer,
     columns,
+    deps,
     footerRenderer,
     dataSource,
     toolbarOptions = props.toolbarOptions || new ToolbarOptions(),
@@ -63,7 +65,7 @@ export const DataGrid: React.FunctionComponent<IProps> = (props) => {
     storage,
   };
 
-  const grid = useDataGrid(columns, gridConfig, dataSource);
+  const grid = useDataGrid(columns, gridConfig, dataSource, deps);
   const [isMobileResolution] = useResolutionSwitch(outerWidth, timeout);
 
   if (isMobileResolution) {

--- a/src/Hooks/index.ts
+++ b/src/Hooks/index.ts
@@ -1,0 +1,7 @@
+import useDataGrid from './useDataGrid';
+import useGridRefresh from './useGridRefresh';
+
+export {
+    useDataGrid,
+    useGridRefresh,
+};

--- a/src/Hooks/useDataGrid.ts
+++ b/src/Hooks/useDataGrid.ts
@@ -47,6 +47,7 @@ const useDataGrid =
         initColumns: ColumnModel[],
         config: Partial<IDataGridConfig>,
         source: any[] | string | Request | ITubularHttpClient,
+        deps?: any[],
     ): IDataGrid => {
 
         const [isLoading, setIsLoading] = React.useState(false);
@@ -175,9 +176,15 @@ const useDataGrid =
             },
         };
 
+        let dependencies = [getColumns, getPage, getSearchText, getItemsPerPage, source];
+
+        if (deps) {
+            dependencies = dependencies.concat(deps);
+        }
+
         React.useEffect(() => {
             api.processRequest();
-        }, [getColumns, getPage, getSearchText, getItemsPerPage]);
+        }, dependencies);
 
         const initGrid = () => {
             if (getStorage.getPage()) {

--- a/src/Hooks/useGridRefresh.ts
+++ b/src/Hooks/useGridRefresh.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+const useGridRefresh = (): [number, () => void] => {
+    const [refresh, setRefreshCounter] = React.useState(0);
+
+    return [refresh, () => {
+        setRefreshCounter(refresh + 1);
+    }];
+};
+
+export default useGridRefresh;


### PR DESCRIPTION
This is a proposal to include ability to refresh the grid. The approach I'm taking is providing a `deps` prop that can be provided to the `useDataGrid` hook, so that any relying party can have control over the refresh on the grid.

In order to implement this functionality you just need to create the dependency, for example:

```tsx
// The refresh is for the deps prop and the forceRefresh method
// will be the one to call to make the grid execute the refresh method
const [refresh, forceRefresh] = useGridRefresh();

const forceGridRefresh = () => {
  forceRefresh();
};

<button onClick={forceGridRefresh}>Force refresh</button>
<DataGrid
  ...
  deps={[refresh]}
/>
```