### PR TITLE
Added missing param on bodyRenderer signature for some components

### DIFF
--- a/sample/src/remoteDataGrid.tsx
+++ b/sample/src/remoteDataGrid.tsx
@@ -5,6 +5,7 @@ import TableRow from '@material-ui/core/TableRow';
 import CheckBox from '@material-ui/icons/CheckBox';
 import CheckBoxOutlineBlank from '@material-ui/icons/CheckBoxOutlineBlank';
 
+import { ColumnModel } from 'tubular-common';
 import { DataGrid, LocalStorage } from '../../src';
 import useGridRefresh from '../../src/Hooks/useGridRefresh';
 import columns from './data/columns';
@@ -20,8 +21,12 @@ const RemoteDataGrid: React.FunctionComponent = () => {
     forceRefresh();
   };
 
-  const bodyRenderer = (row: any) => (
-    <TableRow hover={true} key={row.OrderID}>
+  const rowClick = (row) => {
+    console.log("You clicked on a row: ", row);
+  };
+
+  const bodyRenderer = (row: any, rowIndex: number, gridColumns: ColumnModel[], rowClickProxy: any) => (
+    <TableRow hover={true} key={row.OrderID} onClick={rowClickProxy}>
       <TableCell padding='default'>{row.OrderID}</TableCell>
       <TableCell padding='default'>{row.CustomerName}</TableCell>
       <TableCell padding='default'>
@@ -56,6 +61,7 @@ const RemoteDataGrid: React.FunctionComponent = () => {
         dataSource='https://tubular.azurewebsites.net/api/orders/paged'
         deps={[refresh]}
         bodyRenderer={bodyRenderer}
+        onRowClick={rowClick}
         footerRenderer={footerRenderer}
         storage={new LocalStorage()}
       />

--- a/src/DataGrid/DataGrid.tsx
+++ b/src/DataGrid/DataGrid.tsx
@@ -37,7 +37,12 @@ interface IProps {
   gridName: string;
   storage?: IDataGridStorage;
   toolbarOptions?: ToolbarOptions;
-  bodyRenderer?(row: object, index: number, columns: ColumnModel[]): React.ReactNode;
+  bodyRenderer?(
+    row: any,
+    index: number,
+    columns: ColumnModel[],
+    onRowClickProxy: (row: any) => void,
+  ): React.ReactNode;
   footerRenderer?(aggregate: any): React.ReactNode;
   onError?(err: any): void;
   onRowClick?(row: any): void;

--- a/src/DataGrid/DataGridTable.tsx
+++ b/src/DataGrid/DataGridTable.tsx
@@ -11,7 +11,12 @@ import { GridHeader } from './GridHeader';
 
 interface IProps {
     grid: IDataGrid;
-    bodyRenderer?(row: any, index: number, columns: ColumnModel[]): React.ReactNode;
+    bodyRenderer?(
+        row: any,
+        index: number,
+        columns: ColumnModel[],
+        onRowClickProxy: (row: any) => void,
+    ): React.ReactNode;
     footerRenderer?(aggregate: any): React.ReactNode;
     onRowClick?(row: any): void;
 }

--- a/src/DataGrid/GridBody.tsx
+++ b/src/DataGrid/GridBody.tsx
@@ -26,6 +26,7 @@ const getStyles = (isPointer: boolean) => ({
 
 export const GridBody: React.FunctionComponent<IProps> = ({ grid, bodyRenderer, onRowClick }) => {
     const onRowClickProxy = (row: any) => (ev: React.MouseEvent<HTMLTableRowElement, MouseEvent>) => {
+
         if (onRowClick) {
             onRowClick(row);
         }
@@ -68,7 +69,7 @@ export const GridBody: React.FunctionComponent<IProps> = ({ grid, bodyRenderer, 
                 ? noDataRow
                 : grid.state.data
                     .map((row: any, rowIndex: number) =>
-                        bodyRenderer(row, rowIndex, grid.state.columns, onRowClickProxy))
+                        bodyRenderer(row, rowIndex, grid.state.columns, onRowClickProxy(row)))
             }
         </TableBody>
     );


### PR DESCRIPTION
bodyRenderer param was missing `onRowClickProxy` param for some components.

Also, there was an issue when using a custom bodyRenderer which was not creating closure for onRowClickProxy properly.